### PR TITLE
Fix: Add missing menu resource files

### DIFF
--- a/src/main/resources/menu/border_color.yml
+++ b/src/main/resources/menu/border_color.yml
@@ -1,0 +1,3 @@
+title: "Border Color"
+size: 27
+items: {}

--- a/src/main/resources/menu/upgrade_menu.yml
+++ b/src/main/resources/menu/upgrade_menu.yml
@@ -1,0 +1,3 @@
+title: "Upgrade Menu"
+size: 27
+items: {}


### PR DESCRIPTION
Adds the `border_color.yml` and `upgrade_menu.yml` files to the `src/main/resources/menu/` directory.

The missing `border_color.yml` file was causing a `java.lang.IllegalArgumentException` on plugin startup. The `upgrade_menu.yml` file was also missing and would have caused a similar issue.