### PR TITLE
Fix NoSuchMethodError by not shading Kyori Adventure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
                 <version>3.5.3</version>
                 <configuration>
                     <relocations>
-                        <relocation>
-                            <pattern>net.kyori</pattern>
-                            <shadedPattern>com.minekarta.advancedcorerealms.libs.kyori</shadedPattern>
-                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>
@@ -98,11 +94,13 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
             <version>4.17.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
             <version>4.3.4</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.MilkBowl</groupId>


### PR DESCRIPTION
The plugin was shading and relocating the Kyori Adventure library, which caused a `NoSuchMethodError` when calling `Bukkit.createInventory` because the server provides its own version of the library.

This commit removes the relocation rule from the `maven-shade-plugin` and sets the scope of the Adventure API dependencies to `provided`, which is the standard practice for modern Paper plugins. This ensures that the plugin uses the server-provided Adventure API, resolving the runtime error.