### PR TITLE
feat(menu): Add full color support for menu titles and items

### DIFF
--- a/src/main/java/com/minekarta/advancedcorerealms/menu/Menu.java
+++ b/src/main/java/com/minekarta/advancedcorerealms/menu/Menu.java
@@ -3,6 +3,7 @@ package com.minekarta.advancedcorerealms.menu;
 import com.minekarta.advancedcorerealms.AdvancedCoreRealms;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -26,7 +27,7 @@ public abstract class Menu implements InventoryHolder {
     public Menu(AdvancedCoreRealms plugin, Player player, String title, int size) {
         this.plugin = plugin;
         this.player = player;
-        this.miniMessage = MiniMessage.miniMessage();
+        this.miniMessage = MiniMessage.builder().tags(TagResolver.standard()).build();
         Component inventoryTitle = miniMessage.deserialize(title);
         this.inventory = Bukkit.createInventory(this, size, inventoryTitle);
     }


### PR DESCRIPTION
The previous implementation of MiniMessage did not support hex colors, RGB, or gradients in menu titles and items. This was because the MiniMessage instance was created using `MiniMessage.miniMessage()`, which does not include the standard tag resolvers by default.

This commit updates the `Menu.java` class to build the MiniMessage instance using `MiniMessage.builder().tags(TagResolver.standard()).build()`. This enables the full range of MiniMessage features, including hex colors, RGB, and gradients, ensuring that they will now render correctly in all menus.