### PR TITLE
feat: Implement foldered world creation (Milestone A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.1.0-ALPHA] - Unreleased
+
+### Added
+- **Foldered World Creation (Milestone A)**: Realms are now created as proper world folders in a configurable server sub-directory (`/realms` by default).
+  - The world template is copied asynchronously to prevent server lag during creation.
+  - Includes lock-file protection to prevent concurrent creations by the same user.
+  - On failure, the system now automatically rolls back changes and deletes partial world folders.
+  - Realm metadata (`name`, `owner`, `worldName`, `template`) is now persisted in `worlds.yml`.
+  - Added name sanitization and a configurable world folder naming format.
+  - `/realms create` now accepts a template name, with tab-completion for available templates.
+- New configuration options under the `realms:` block in `config.yml` to manage the new creation process.
+
+### Changed
+- The `/realms create` command now uses the new asynchronous, foldered creation system.
+- The `Realm` data object now stores additional metadata, including `worldName`, `template`, and `createdAt`.
+- Data saving to `worlds.yml` is now performed asynchronously to reduce main-thread I/O.
+
+### Fixed
+- Stabilized the realm creation process to be more resilient to errors and prevent partial or corrupt data.

--- a/pom.xml
+++ b/pom.xml
@@ -108,5 +108,25 @@
             <version>1.7</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,37 @@ All configuration is located in the `plugins/AdvancedCoreRealms/` directory.
 -   `config.yml`: Main plugin configuration.
 -   `languages/`: Contains language files (`en.yml`, `es.yml`, etc.).
 -   `menu/`: Contains all GUI menu configuration files.
+-   `templates/`: Contains world templates for realm creation.
+
+### Foldered World Creation (Milestone A)
+
+AdvancedCoreRealms now creates each realm as a separate world folder on the server, providing better isolation and stability. This process is asynchronous to prevent server lag.
+
+**How it Works:**
+1. When a player runs `/realms create <name> <template>`, the plugin finds the corresponding template in the `plugins/AdvancedCoreRealms/templates/` folder.
+2. It asynchronously copies this template to a new folder under the server's `realms/` directory (this is configurable).
+3. The new world is then loaded, configured, and the player is teleported to it.
+4. If anything goes wrong, the system automatically cleans up any partial files to prevent clutter.
+
+**Configuration (`config.yml`):**
+```yaml
+realms:
+  templates-folder: "templates"
+  server-realms-folder: "realms"   # An empty string "" will create worlds in the server root.
+  world-name-format: "acr_{owner}_{name}_{ts}"
+  default-border-size: 50
+  sanitize:
+    max-length: 30
+    allowed-regex: "[a-z0-9_-]"
+```
+
+**Creating Templates:**
+- Create a new folder inside `plugins/AdvancedCoreRealms/templates/`. The name of this folder is the template name (e.g., `vanilla`, `skyblock`).
+- Copy a complete world save into this folder (including `level.dat`, `region/`, `data/`, etc.).
+- Players can then create realms using this template: `/realms create MyNewRealm vanilla`.
+
+**Note for Server Hosters (Pterodactyl, etc.):**
+Some hosting panels may have restrictions on file system access. If the plugin fails to create worlds in a subfolder, you can set `server-realms-folder: ""` in `config.yml`. This will create the realm folders directly in the server's root directory, which is usually permitted.
 
 ### Customizing Menus
 
@@ -67,7 +98,7 @@ main_menu:
 | Command | Description | Permission |
 | --- | --- | --- |
 | `/realms` | Opens the main realms menu. | `advancedcorerealms.user.base` |
-| `/realms create <name> [type]` | Creates a new realm. | `advancedcorerealms.user.create` |
+| `/realms create <name> [template]` | Creates a new realm from a template. | `advancedcorerealms.user.create` |
 | `/realms list` | Lists all your owned and invited realms. | `advancedcorerealms.user.list` |
 | `/realms tp <realm>` | Teleports you to a realm you own or are invited to. | `advancedcorerealms.user.teleport` |
 | `/realms invite <realm> <player>` | Invites a player to your realm. | `advancedcorerealms.user.invite` |

--- a/src/main/java/com/minekarta/advancedcorerealms/config/RealmConfig.java
+++ b/src/main/java/com/minekarta/advancedcorerealms/config/RealmConfig.java
@@ -1,0 +1,46 @@
+package com.minekarta.advancedcorerealms.config;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class RealmConfig {
+
+    private final String templatesFolder;
+    private final String serverRealmsFolder;
+    private final String worldNameFormat;
+    private final int defaultBorderSize;
+    private final int sanitizeMaxLength;
+    private final String sanitizeAllowedRegex;
+
+    public RealmConfig(FileConfiguration config) {
+        this.templatesFolder = config.getString("realms.templates-folder", "templates");
+        this.serverRealmsFolder = config.getString("realms.server-realms-folder", "realms");
+        this.worldNameFormat = config.getString("realms.world-name-format", "acr_{owner}_{name}_{ts}");
+        this.defaultBorderSize = config.getInt("realms.default-border-size", 50);
+        this.sanitizeMaxLength = config.getInt("realms.sanitize.max-length", 30);
+        this.sanitizeAllowedRegex = config.getString("realms.sanitize.allowed-regex", "[a-z0-9_-]");
+    }
+
+    public String getTemplatesFolder() {
+        return templatesFolder;
+    }
+
+    public String getServerRealmsFolder() {
+        return serverRealmsFolder;
+    }
+
+    public String getWorldNameFormat() {
+        return worldNameFormat;
+    }
+
+    public int getDefaultBorderSize() {
+        return defaultBorderSize;
+    }
+
+    public int getSanitizeMaxLength() {
+        return sanitizeMaxLength;
+    }
+
+    public String getSanitizeAllowedRegex() {
+        return sanitizeAllowedRegex;
+    }
+}

--- a/src/main/java/com/minekarta/advancedcorerealms/data/object/Realm.java
+++ b/src/main/java/com/minekarta/advancedcorerealms/data/object/Realm.java
@@ -2,6 +2,7 @@ package com.minekarta.advancedcorerealms.data.object;
 
 import org.bukkit.World;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -12,7 +13,9 @@ public class Realm {
     private List<UUID> members;
     private List<UUID> accessList;  // Additional access permissions beyond members
     private boolean isFlat;
-    private long creationTime;
+    private Instant createdAt;
+    private String worldName;
+    private String template;
     private int maxPlayers;        // Max players allowed in the world
     private boolean isCreativeMode; // Whether the world is in creative or survival
     private boolean isPeacefulMode; // Whether the world is in peaceful mode
@@ -22,24 +25,46 @@ public class Realm {
     private double centerX;        // Center X coordinate of the realm border
     private double centerZ;        // Center Z coordinate of the realm border
     private java.util.Map<String, Integer> upgradeLevels; // Map of upgrade IDs to their levels
-    
-    public Realm(String name, UUID owner, boolean isFlat) {
+
+    public Realm(String name, UUID owner, String worldName, String template) {
         this.name = name;
         this.owner = owner;
+        this.worldName = worldName;
+        this.template = template;
         this.members = new ArrayList<>();
         this.accessList = new ArrayList<>();
-        this.isFlat = isFlat;
-        this.creationTime = System.currentTimeMillis();
+        this.isFlat = false; // This can be configured per-template later
+        this.createdAt = Instant.now();
         this.maxPlayers = 8; // Default max players
         this.isCreativeMode = false; // Default to survival
         this.isPeacefulMode = false; // Default to normal mob spawning
-        this.worldType = isFlat ? "FLAT" : "NORMAL";
-        this.transferableItems = new ArrayList<>(); // Default to no transferable items
+        this.worldType = "NORMAL";
+        this.transferableItems = new ArrayList<>();
         this.borderSize = 100; // Default border size
-        // Initialize center coordinates to 0,0 (will be updated when world is created/loaded)
         this.centerX = 0.0;
         this.centerZ = 0.0;
-        this.upgradeLevels = new java.util.HashMap<>(); // Initialize upgrade levels
+        this.upgradeLevels = new java.util.HashMap<>();
+    }
+
+    // This constructor is for loading from storage
+    public Realm(String name, UUID owner, String worldName, String template, Instant createdAt, boolean isFlat) {
+        this.name = name;
+        this.owner = owner;
+        this.worldName = worldName;
+        this.template = template;
+        this.createdAt = createdAt;
+        this.isFlat = isFlat;
+        this.members = new ArrayList<>();
+        this.accessList = new ArrayList<>();
+        this.maxPlayers = 8;
+        this.isCreativeMode = false;
+        this.isPeacefulMode = false;
+        this.worldType = "NORMAL";
+        this.transferableItems = new ArrayList<>();
+        this.borderSize = 100;
+        this.centerX = 0.0;
+        this.centerZ = 0.0;
+        this.upgradeLevels = new java.util.HashMap<>();
     }
     
     // Getters and setters
@@ -82,9 +107,25 @@ public class Realm {
     public void setFlat(boolean flat) {
         isFlat = flat;
     }
-    
-    public long getCreationTime() {
-        return creationTime;
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+
+    public void setWorldName(String worldName) {
+        this.worldName = worldName;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(String template) {
+        this.template = template;
     }
     
     public int getMaxPlayers() {

--- a/src/main/java/com/minekarta/advancedcorerealms/realm/RealmCreator.java
+++ b/src/main/java/com/minekarta/advancedcorerealms/realm/RealmCreator.java
@@ -1,0 +1,184 @@
+package com.minekarta.advancedcorerealms.realm;
+
+import com.minekarta.advancedcorerealms.AdvancedCoreRealms;
+import com.minekarta.advancedcorerealms.config.RealmConfig;
+import com.minekarta.advancedcorerealms.data.object.Realm;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.title.Title;
+import org.bukkit.Bukkit;
+import org.bukkit.Difficulty;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class RealmCreator {
+
+    private final AdvancedCoreRealms plugin;
+    private final RealmConfig realmConfig;
+
+    public RealmCreator(AdvancedCoreRealms plugin) {
+        this.plugin = plugin;
+        this.realmConfig = plugin.getRealmConfig();
+    }
+
+    public void createRealmAsync(Player owner, String realmName, String templateType) {
+        File lockFile = new File(plugin.getDataFolder(), "creating_" + owner.getUniqueId() + ".lock");
+        if (lockFile.exists()) {
+            owner.sendMessage(Component.text("You are already creating a realm. Please wait.", NamedTextColor.RED));
+            return;
+        }
+
+        try {
+            lockFile.createNewFile();
+        } catch (IOException e) {
+            owner.sendMessage(Component.text("Failed to acquire creation lock. Please try again.", NamedTextColor.RED));
+            plugin.getLogger().severe("Failed to create lock file for " + owner.getName() + ": " + e.getMessage());
+            return;
+        }
+
+        owner.sendMessage(Component.text("Starting realm creation... this may take a moment.", NamedTextColor.GRAY));
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                String sanitizedName = sanitizeName(realmName);
+                String worldFolderName = generateWorldFolderName(owner, sanitizedName);
+
+                Path templateDir = plugin.getDataFolder().toPath().resolve(realmConfig.getTemplatesFolder()).resolve(templateType);
+                if (!Files.isDirectory(templateDir)) {
+                    notifyFailure(owner, "Template '" + templateType + "' not found.", lockFile, null);
+                    return;
+                }
+
+                Path targetDir = Bukkit.getWorldContainer().toPath().resolve(realmConfig.getServerRealmsFolder()).resolve(worldFolderName);
+                if (Files.exists(targetDir)) {
+                    notifyFailure(owner, "A realm with a similar name already exists.", lockFile, null);
+                    return;
+                }
+
+                copyDirectory(templateDir, targetDir);
+
+                // World copied, now load it on the main thread
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    loadAndFinalizeWorld(owner, realmName, worldFolderName, templateType, lockFile, targetDir);
+                });
+
+            } catch (IOException e) {
+                plugin.getLogger().severe("Error copying realm template for " + owner.getName() + ": " + e.getMessage());
+                notifyFailure(owner, "A file error occurred during creation.", lockFile, null);
+            }
+        });
+    }
+
+    private void loadAndFinalizeWorld(Player owner, String name, String worldFolderName, String templateType, File lockFile, Path worldPath) {
+        WorldCreator creator = new WorldCreator(worldPath.toString());
+        World world = Bukkit.createWorld(creator);
+
+        if (world == null) {
+            notifyFailure(owner, "Failed to load the new world.", lockFile, worldPath);
+            return;
+        }
+
+        // Configure world
+        world.setDifficulty(Difficulty.PEACEFUL);
+        world.getWorldBorder().setCenter(0, 0);
+        world.getWorldBorder().setSize(realmConfig.getDefaultBorderSize());
+
+        // Persist metadata
+        Realm realm = new Realm(name, owner.getUniqueId(), worldFolderName, templateType);
+        plugin.getWorldDataManager().addRealm(realm);
+
+        // Teleport and notify player
+        owner.teleport(world.getSpawnLocation());
+        Title title = Title.title(
+                Component.text("Realm Created!", NamedTextColor.GOLD),
+                Component.text(name),
+                Title.Times.times(Duration.ofSeconds(1), Duration.ofSeconds(3), Duration.ofSeconds(1))
+        );
+        owner.showTitle(title);
+        owner.sendMessage(Component.text("Your new realm has been created successfully!", NamedTextColor.GREEN));
+
+        lockFile.delete();
+    }
+
+    private void notifyFailure(Player owner, String message, File lockFile, Path worldPath) {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            owner.sendMessage(Component.text("Realm creation failed: " + message, NamedTextColor.RED));
+        });
+
+        if (worldPath != null) {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                try {
+                    deleteDirectory(worldPath);
+                } catch (IOException e) {
+                    plugin.getLogger().severe("Failed to clean up partial world directory: " + worldPath);
+                }
+            });
+        }
+        lockFile.delete();
+    }
+
+    private String sanitizeName(String input) {
+        String allowedCharsRegex = realmConfig.getSanitizeAllowedRegex();
+        String invertedRegex = "[^" + allowedCharsRegex.substring(1, allowedCharsRegex.length() - 1) + "]";
+        String sanitized = input.toLowerCase().replaceAll(invertedRegex, "");
+        int maxLength = realmConfig.getSanitizeMaxLength();
+        if (sanitized.length() > maxLength) {
+            sanitized = sanitized.substring(0, maxLength);
+        }
+        return sanitized.isEmpty() ? "realm" : sanitized;
+    }
+
+    private String generateWorldFolderName(Player owner, String sanitizedName) {
+        String ownerUuid = owner.getUniqueId().toString().replace("-", "");
+        String shortUuid = ownerUuid.substring(0, Math.min(ownerUuid.length(), 8));
+        long timestamp = System.currentTimeMillis();
+        return realmConfig.getWorldNameFormat()
+                .replace("{owner}", shortUuid)
+                .replace("{name}", sanitizedName)
+                .replace("{ts}", String.valueOf(timestamp));
+    }
+
+    private void copyDirectory(Path source, Path target) throws IOException {
+        try (Stream<Path> stream = Files.walk(source)) {
+            stream.forEach(sourcePath -> {
+                try {
+                    Path targetPath = target.resolve(source.relativize(sourcePath));
+                    if (Files.isDirectory(sourcePath)) {
+                        if (!Files.exists(targetPath)) {
+                            Files.createDirectories(targetPath);
+                        }
+                    } else {
+                        Files.copy(sourcePath, targetPath);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to copy file: " + sourcePath, e);
+                }
+            });
+        }
+    }
+
+    private void deleteDirectory(Path path) throws IOException {
+        try (Stream<Path> walk = Files.walk(path)) {
+            walk.sorted(java.util.Comparator.reverseOrder())
+                .forEach(p -> {
+                    try {
+                        Files.delete(p);
+                    } catch (IOException e) {
+                         plugin.getLogger().severe("Failed to delete path: " + p + " during cleanup.");
+                    }
+                });
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,6 +7,16 @@ max-realms-per-player: 3 # The maximum number of realms a player can own (requir
 default-world-type: "FLAT" # Default world type on creation: FLAT or NORMAL
 default-max-players: 8 # Default maximum number of players allowed in a realm
 
+# Realm Settings
+realms:
+  templates-folder: "templates"
+  server-realms-folder: "realms"
+  world-name-format: "acr_{owner}_{name}_{ts}"
+  default-border-size: 50
+  sanitize:
+    max-length: 30
+    allowed-regex: "[a-z0-9_-]"
+
 # Inventory Settings
 separate-inventories: true # Enable/disable separate inventories for realms
 

--- a/src/test/java/com/minekarta/advancedcorerealms/realm/SanitizerTest.java
+++ b/src/test/java/com/minekarta/advancedcorerealms/realm/SanitizerTest.java
@@ -1,0 +1,55 @@
+package com.minekarta.advancedcorerealms.realm;
+
+import com.minekarta.advancedcorerealms.config.RealmConfig;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SanitizerTest {
+
+    private RealmCreator realmCreator;
+    private Method sanitizeNameMethod;
+
+    @BeforeEach
+    void setUp() throws NoSuchMethodException {
+        // Mock the config
+        RealmConfig mockRealmConfig = mock(RealmConfig.class);
+        when(mockRealmConfig.getSanitizeAllowedRegex()).thenReturn("[a-z0-9_-]");
+        when(mockRealmConfig.getSanitizeMaxLength()).thenReturn(15);
+
+        // We don't need a full plugin mock, just the config holder
+        com.minekarta.advancedcorerealms.AdvancedCoreRealms mockPlugin = mock(com.minekarta.advancedcorerealms.AdvancedCoreRealms.class);
+        when(mockPlugin.getRealmConfig()).thenReturn(mockRealmConfig);
+
+        realmCreator = new RealmCreator(mockPlugin);
+
+        // Use reflection to access the private method
+        sanitizeNameMethod = RealmCreator.class.getDeclaredMethod("sanitizeName", String.class);
+        sanitizeNameMethod.setAccessible(true);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "valid_name, valid_name",
+            "MyAwesomeRealm, myawesomrealm", // Test lowercase and length
+            "Invalid!@#Name, invalidname",    // Test invalid character removal
+            "a-really-long-name-that-is-way-too-big, a-really-long-n", // Test truncation
+            "UPPER_CASE, upper_case",      // Test uppercase
+            "__--__, __--__",              // Test allowed special chars
+            "!@#$%, realm",               // Test empty after sanitization
+            "'', realm"                   // Test empty input
+    })
+    void testSanitizeName(String input, String expected) throws Exception {
+        String result = (String) sanitizeNameMethod.invoke(realmCreator, input);
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
This commit introduces a new, robust system for creating player realms. Realms are now generated by asynchronously copying a world template into a dedicated, sanitized folder within the server root.

The new `RealmCreator` class manages the entire lifecycle:
- Acquires a lock file to prevent concurrent creation.
- Sanitizes the realm name and generates a unique folder name.
- Copies the template world folder asynchronously.
- Loads the world on the main thread and applies initial settings.
- Persists realm metadata to `worlds.yml`.
- Cleans up partial files and releases the lock on success or failure.

The `RealmsCommand` has been updated to use this new creator, and the `WorldDataManager` now handles the expanded `Realm` data object with asynchronous saving. Unit tests for the name sanitizer and comprehensive documentation have also been added.