### PR TITLE
Fix NullPointerException in RealmCreator

### DIFF
--- a/src/main/java/com/minekarta/advancedcorerealms/AdvancedCoreRealms.java
+++ b/src/main/java/com/minekarta/advancedcorerealms/AdvancedCoreRealms.java
@@ -61,6 +61,11 @@ public class AdvancedCoreRealms extends JavaPlugin {
         this.guiManager = new GUIManager(this);
         this.upgradeManager = new UpgradeManager(this);
         this.playerStateManager = new PlayerStateManager(this);
+
+        // Load configuration
+        saveDefaultConfig();
+        this.realmConfig = new RealmConfig(getConfig());
+
         this.realmCreator = new RealmCreator(this);
         
         // Initialize storage and services
@@ -73,9 +78,6 @@ public class AdvancedCoreRealms extends JavaPlugin {
             new AdvancedCoreRealmsPlaceholder(this).register();
         }
         
-        // Load configuration
-        saveDefaultConfig();
-        this.realmConfig = new RealmConfig(getConfig());
         this.languageManager.loadLanguage();
         
         // Load upgrades and initialize economy


### PR DESCRIPTION
The `RealmCreator` was being instantiated before the `RealmConfig` was loaded, leading to a `NullPointerException` when calling `sanitizeName`.

This commit reorders the initialization in the `onEnable` method of the main plugin class to ensure that `RealmConfig` is initialized before it is accessed by `RealmCreator`.