### PR TITLE
Fix: Reorder manager initialization to prevent NullPointerException

### DIFF
--- a/src/main/java/com/minekarta/advancedcorerealms/AdvancedCoreRealms.java
+++ b/src/main/java/com/minekarta/advancedcorerealms/AdvancedCoreRealms.java
@@ -93,13 +93,13 @@ public class AdvancedCoreRealms extends JavaPlugin {
 
         // Initialize managers
         this.languageManager = new LanguageManager(this);
+        this.realmManager = new RealmManager(this);
         this.worldManager = new WorldManager(this);
         this.inviteManager = new InviteManager(this);
         this.menuManager = new MenuManager(this);
         this.guiManager = new GUIManager(this);
         this.upgradeManager = new UpgradeManager(this);
         this.playerStateManager = new PlayerStateManager(this);
-        this.realmManager = new RealmManager(this);
         this.worldBorderManager = new WorldBorderManager(this);
 
         // Load configuration


### PR DESCRIPTION
This commit fixes a NullPointerException that occurred in `WorldManager` when `teleportToRealm` was called. The root cause was that `WorldManager` was being initialized before `RealmManager`, despite `WorldManager` having a dependency on `RealmManager`.

By reordering the initializations in the `onEnable` method of `AdvancedCoreRealms.java`, this commit ensures that `RealmManager` is available when `WorldManager` is created, thus resolving the null reference issue.